### PR TITLE
Corriger les dépréciations dans le workflow deploy-release

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -11,9 +11,9 @@ jobs:
         contents: write
         id-token: write
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
         - name: Set up JDK
-          uses: actions/setup-java@v4
+          uses: actions/setup-java@v5
           with:
             java-version: '17'
             distribution: 'temurin'
@@ -32,7 +32,7 @@ jobs:
           run: mvn clean deploy -Pci-publish --no-transfer-progress
         - name: Get current version
           id: version
-          run: echo "::set-output name=prop::$(mvn -f pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)"
+          run: echo "prop=$(mvn -f pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_OUTPUT
         - run: echo ${{steps.version.outputs.prop}}
         - run: mv target/boot-properties-logger-starter-${{steps.version.outputs.prop}}.jar target/boot-properties-logger-starter.jar
         - name: Create Release


### PR DESCRIPTION
- Remplacer la commande set-output dépréciée par $GITHUB_OUTPUT
- Mettre à jour actions/checkout de v4 vers v5 (support Node 24)
- Mettre à jour actions/setup-java de v4 vers v5 (support Node 24)

Closes #53